### PR TITLE
Redesign homepage and improve layout metadata

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,15 @@
 ---
+interface Props {
+  title?: string;
+  description?: string;
+}
 
+const {
+  title = "Stephen Park",
+  description = "Senior Software Engineer based in Seattle, WA. Personal website and photography portfolio.",
+} = Astro.props;
+
+const pageTitle = title === "Stephen Park" ? title : `${title} | Stephen Park`;
 ---
 
 <!doctype html>
@@ -10,18 +20,19 @@
 >
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="description"
-      content="Welcome to my personal website and photography portfolio"
-    />
+    <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="generator" content={Astro.generator} />
-    <title>Stephen Park</title>
+    <title>{pageTitle}</title>
+    <!-- Open Graph -->
+    <meta property="og:title" content={pageTitle} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
   </head>
-  <body class="px-16 py-8">
+  <body class="px-4 sm:px-8 md:px-16 py-8 pb-20">
     <slot />
-    <footer class="footer footer-center fixed inset-x-0 bottom-5">
+    <footer class="footer footer-center fixed inset-x-0 bottom-0 py-4 bg-base-100/80 backdrop-blur-sm border-t border-base-300">
       <aside>
         <p>
           Built with <a

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,25 +10,27 @@ import Prose from "../components/Prose.astro";
 <Layout>
   <main>
     <Prose>
-      <h2>Welcome</h2>
-      <div class="avatar">
-        <div class="w-64 rounded">
-          <Image
-            src="https://stephen-park-personal-website-public.s3.amazonaws.com/assets/headshot.jpg"
-            alt="headshot"
-            width="256"
-            height="256"
-          />
+      <h1>Stephen Park</h1>
+      <div class="not-prose flex items-center gap-4 mb-4">
+        <div class="avatar">
+          <div class="w-24 rounded-full">
+            <Image
+              src="https://stephen-park-personal-website-public.s3.amazonaws.com/assets/headshot.jpg"
+              alt="Stephen Park headshot"
+              width="96"
+              height="96"
+            />
+          </div>
+        </div>
+        <div>
+          <p class="text-lg font-semibold">Senior Software Engineer</p>
+          <p class="text-base-content/70">Seattle, Washington</p>
         </div>
       </div>
       <p>
-        Hello! My name is <b>Stephen Park</b>. I'm a remote <b
-          >Senior Software Engineer</b
-        > based out of <b>Seattle, Washington</b>.
-      </p>
-      <p>
-        I enjoy trying out new frameworks and tools, foreign language learning,
-        basketball, travel, and <a
+        Hello! I'm a remote software engineer who enjoys trying out new
+        frameworks and tools, foreign language learning, basketball, travel,
+        and <a
           href="https://glass.photo/stephen-park"
           target="_blank"
           rel="noreferrer"
@@ -36,14 +38,39 @@ import Prose from "../components/Prose.astro";
         >.
       </p>
       <p>
-        For more detailed information, check out my
-        <a
+        For more, check out my <a
           href="https://stephen-park-personal-website-public.s3.amazonaws.com/assets/StephenParkResume2025.pdf"
           target="_blank"
           rel="noreferrer"
           class="link">resume</a
-        >!
+        >.
       </p>
+      <div class="not-prose flex gap-4 mt-6">
+        <a
+          href="https://github.com/stephenspark"
+          target="_blank"
+          rel="noreferrer"
+          class="btn btn-outline btn-sm"
+        >
+          GitHub
+        </a>
+        <a
+          href="https://www.linkedin.com/in/stephenspark"
+          target="_blank"
+          rel="noreferrer"
+          class="btn btn-outline btn-sm"
+        >
+          LinkedIn
+        </a>
+        <a
+          href="https://glass.photo/stephen-park"
+          target="_blank"
+          rel="noreferrer"
+          class="btn btn-outline btn-sm"
+        >
+          Photography
+        </a>
+      </div>
     </Prose>
   </main>
 </Layout>


### PR DESCRIPTION
## Summary
This PR redesigns the homepage with an improved visual layout and enhances the site's metadata handling for better SEO and social sharing.

## Key Changes

**Homepage Redesign (src/pages/index.astro):**
- Changed main heading from "Welcome" to "Stephen Park" (h1)
- Redesigned avatar section: reduced size from 256px to 96px and made it circular
- Repositioned avatar and title info side-by-side using flexbox layout
- Added professional title and location display next to avatar
- Simplified introductory text for better readability
- Added social media buttons (GitHub, LinkedIn, Photography) with consistent styling
- Applied `not-prose` class to preserve button styling within Prose component

**Layout Improvements (src/layouts/Layout.astro):**
- Added Props interface to support dynamic page titles and descriptions
- Implemented configurable metadata with sensible defaults
- Added Open Graph meta tags for improved social media sharing
- Updated page title logic to append "| Stephen Park" for non-homepage pages
- Improved responsive padding: `px-4 sm:px-8 md:px-16` for mobile-first design
- Enhanced footer styling with semi-transparent background, backdrop blur, and border
- Added bottom padding to body to prevent content overlap with fixed footer

## Notable Details
- Avatar now uses `rounded-full` for circular appearance
- Social buttons use DaisyUI's `btn btn-outline btn-sm` classes
- Layout supports dynamic page titles while maintaining consistent branding
- Footer now has better visual separation with backdrop blur effect

https://claude.ai/code/session_01L3izUTtMsBbgbBsDD3tBEd